### PR TITLE
Change switch statement indentation to match demo.odin

### DIFF
--- a/compiler/odin.vim
+++ b/compiler/odin.vim
@@ -1,0 +1,6 @@
+if exists("b:did_compiler")
+  finish
+endif
+let b:did_compiler = 1
+
+setlocal errorformat=%f(%l:%c)\ %m

--- a/ftplugin/odin.vim
+++ b/ftplugin/odin.vim
@@ -1,0 +1,6 @@
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+compiler odin

--- a/indent/odin.vim
+++ b/indent/odin.vim
@@ -6,6 +6,7 @@ let b:did_indent = 1
 setlocal nosmartindent
 setlocal nolisp
 setlocal autoindent
+
 setlocal indentexpr=GetOdinIndent(v:lnum)
 
 if exists("*GetOdinIndent")
@@ -28,7 +29,7 @@ function! GetOdinIndent(lnum)
     let ind += &sw
   endif
 
-  " Indent f previous line is a case statement
+  " Indent if previous line is a case statement
   if prevline =~ '^\s*case .*:$'
     let ind += &sw
   endif

--- a/indent/odin.vim
+++ b/indent/odin.vim
@@ -39,8 +39,8 @@ function! GetOdinIndent(lnum)
   endif
 
   " Un-indent if current line is a case statement
-  if line =~# '^\s*case .*\:$'
-    let ind -= shiftwidth()
+  if line =~ '^\s*case .*\:$'
+    let ind -= &sw
   endif
 
   return ind

--- a/indent/odin.vim
+++ b/indent/odin.vim
@@ -30,7 +30,7 @@ function! GetOdinIndent(lnum)
   endif
 
   " Indent if previous line is a case statement
-  if prevline =~ '^\s*case .*:$'
+  if prevline =~ '^\s*case.*:$'
     let ind += &sw
   endif
 
@@ -39,7 +39,7 @@ function! GetOdinIndent(lnum)
   endif
 
   " Un-indent if current line is a case statement
-  if line =~ '^\s*case .*:$'
+  if line =~ '^\s*case.*:$'
     let ind -= &sw
   endif
 

--- a/indent/odin.vim
+++ b/indent/odin.vim
@@ -6,12 +6,9 @@ let b:did_indent = 1
 setlocal nosmartindent
 setlocal nolisp
 setlocal autoindent
+setlocal cino+=:0
 
 setlocal indentexpr=GetOdinIndent(v:lnum)
-
-if exists("*GetOdinIndent")
-  finish
-endif
 
 function! GetOdinIndent(lnum)
   let prev = prevnonblank(a:lnum-1)
@@ -29,8 +26,18 @@ function! GetOdinIndent(lnum)
     let ind += &sw
   endif
 
+  " Indent f previous line is a case statement
+  if prevline =~ '^\s*case .*:$'
+    let ind += &sw
+  endif
+
   if line =~ '^\s*[)}]'
     let ind -= &sw
+  endif
+
+  " Un-indent if current line is a case statement
+  if line =~# '^\s*case .*\:$'
+    let ind -= shiftwidth()
   endif
 
   return ind

--- a/indent/odin.vim
+++ b/indent/odin.vim
@@ -39,7 +39,7 @@ function! GetOdinIndent(lnum)
   endif
 
   " Un-indent if current line is a case statement
-  if line =~ '^\s*case .*\:$'
+  if line =~ '^\s*case .*:$'
     let ind -= &sw
   endif
 

--- a/syntax/odin.vim
+++ b/syntax/odin.vim
@@ -34,7 +34,7 @@ syntax match odinFixMe "FIXME"
 syntax match odinNoCheckin "NOCHECKIN"
 syntax match odinHack "HACK"
 
-syntax keyword odinDataType string bool b8 b16 b32 b64 rune any rawptr f32 f64 f32le f32be f64le f64be u8 u16 u32 u64 u128 u16le u32le u64le u128le u16be u32be u64be u128be uint i8 i16 i32 i64 i128 i16le i32le i64le i128le i16be i32be i64be i128be int
+syntax keyword odinDataType string cstring bool b8 b16 b32 b64 rune any rawptr f32 f64 f32le f32be f64le f64be u8 u16 u32 u64 u128 u16le u32le u64le u128le u16be u32be u64be u128be uint i8 i16 i32 i64 i128 i16le i32le i64le i128le i16be i32be i64be i128be int
 syntax keyword odinBool true false
 syntax keyword odinNull nil
 syntax keyword odinDynamic dynamic


### PR DESCRIPTION
Based on go.vim's switch statement indendation.