### PR TITLE
Add missing keywords

### DIFF
--- a/syntax/odin.vim
+++ b/syntax/odin.vim
@@ -2,9 +2,12 @@ if exists("b:current_syntax")
   finish
 endif
 
+syntax keyword odinAsm asm
+syntax keyword odinContext context
 syntax keyword odinUsing using
 syntax keyword odinTransmute transmute
 syntax keyword odinCast cast
+syntax keyword odinAutoCast auto_cast
 syntax keyword odinDistinct distinct
 syntax keyword odinOpaque opaque
 syntax keyword odinWhere where
@@ -24,6 +27,7 @@ syntax keyword odinSwitch switch
 syntax keyword odinCase case
 syntax keyword odinContinue continue
 syntax keyword odinBreak break
+syntax keyword odinFallthrough fallthrough
 syntax keyword odinSizeOf size_of
 syntax keyword odinOffsetOf offset_of
 syntax keyword odinTypeInfoOf type_info_of
@@ -33,6 +37,8 @@ syntax keyword odinAlignOf align_of
 
 syntax keyword odinOrReturn or_return
 syntax keyword odinOrElse or_else
+syntax keyword odinOrBreak or_break
+syntax keyword odinOrContinue or_continue
 
 syntax keyword odinInline inline
 syntax keyword odinNoInline no_inline
@@ -99,9 +105,12 @@ syntax match odinCommentNote "@\<\w\+\>" contained display
 syntax region odinLineComment start=/\/\// end=/$/  contains=odinCommentNote, odinTodo, odinNote, odinXXX, odinFixMe, odinNoCheckin, odinHack
 syntax region odinBlockComment start=/\v\/\*/ end=/\v\*\// contains=odinBlockComment, odinCommentNote, odinTodo, odinNote, odinXXX, odinFixMe, odinNoCheckin, odinHack
 
+highlight link odinAsm Keyword
+highlight link odinContext Keyword
 highlight link odinUsing Keyword
 highlight link odinTransmute Keyword
 highlight link odinCast Keyword
+highlight link odinAutoCast Keyword
 highlight link odinDistinct Keyword
 highlight link odinOpaque Keyword
 highlight link odinReturn Keyword
@@ -112,6 +121,7 @@ highlight link odinIn Keyword
 highlight link odinNotIn Keyword
 highlight link odinContinue Keyword
 highlight link odinBreak Keyword
+highlight link odinFallthrough Keyword
 highlight link odinSizeOf Keyword
 highlight link odinOffsetOf Keyword
 highlight link odinTypeOf Keyword
@@ -121,6 +131,8 @@ highlight link odinAlignOf Keyword
 highlight link odinPackage Keyword
 highlight link odinOrReturn Keyword
 highlight link odinOrElse Keyword
+highlight link odinOrBreak Keyword
+highlight link odinOrContinue Keyword
 highlight link odinWhere Keyword
 
 highlight link odinInline Keyword


### PR DESCRIPTION
I think `asm` is unimplemented at the moment, but it couldn't hurt to have it in there. Did a quick skim of the tokenizer for this one.