### PR TITLE
Switch to using shiftwidth() instead of '&sw'

### DIFF
--- a/indent/odin.vim
+++ b/indent/odin.vim
@@ -26,11 +26,11 @@ function! GetOdinIndent(lnum)
   let ind = indent(prev)
 
   if prevline =~ '[({]\s*$'
-    let ind += &sw
+    let ind += shiftwidth()
   endif
 
   if line =~ '^\s*[)}]'
-    let ind -= &sw
+    let ind -= shiftwidth()
   endif
 
   return ind


### PR DESCRIPTION
'&sw' will indent/dedent by 0 when set to 0. shiftwidth() will use 'tabstop' when 'shiftwidth' is 0.